### PR TITLE
Created CachedDirectional for inputs

### DIFF
--- a/Assets/Code/Player/PlayerInputManager.cs
+++ b/Assets/Code/Player/PlayerInputManager.cs
@@ -49,6 +49,8 @@ public class PlayerInputManager : MonoBehaviour
     void FixedUpdate()
     {
         pib.debugMessages = inputBufferDebugMessages;
+        pib.CacheCurrentDirectional();
+
         foreach (ControlLock.Controls control in controlPriorityList)
         {
             if (pib.TryGetBuffer(control, out List<Pair<int, CharacterInput>> buffer) && buffer.Count > 0)
@@ -133,7 +135,7 @@ public class PlayerInputManager : MonoBehaviour
         // basically if elses testing the input.Direction value
     }
 
-    private bool CanInput(ControlLock.Controls controls, out string debugStr)
+    public bool CanInput(ControlLock.Controls controls, out string debugStr)
     {
         bool controlsAllowed = controlLockManager.ControlsAllowed(controls);
         if (debugMessages)
@@ -146,6 +148,16 @@ public class PlayerInputManager : MonoBehaviour
             debugStr = "";
         }
         return controlsAllowed;
+    }
+
+    public CharacterInput.DirectedInput GetCurrentDirectional()
+    {
+        return pib.CachedDirectional;
+    }
+
+    public Vector2 GetCurrentDirection()
+    {
+        return pib.CachedDirectional.current;
     }
 
     private void DebugAllowedInput(string debugStart, CharacterInput input)

--- a/Assets/Code/Player/PlayerInputManager.cs.meta
+++ b/Assets/Code/Player/PlayerInputManager.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -50
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
CachedDirectional is used to store the current directional input of the player. This is used to update all held down buttons, updating their current direction (but not altering them from their original directional settings). The current direction vector2 is available from PlayerInputManager.GetCurrentDirection() and the cached CharacterInput.DirectedInput is available from PlayerInputManager.GetCurrentDirectional().

I also changed the CharacterInput.Direction data type to be CharacterInput.DirectedInput. This data type has three values:
- CardinalDirection cardinalInput: one of the values listed in the CharacterInput.CardinalDirection enum, corresponding to any 45 degree input (e.g. right or down left). This value shouldn't change.
- Vector2 starting: the initial direction of this directed input. This value shouldn't change.
- Vector2 current: the current direction of this directed input. This value current is udpated every frame so that if this input is held down, it will update current to be the direction that the player is inputting for movement.